### PR TITLE
ensure we don't end up with [ undefined ] results

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function loader (source) {
 
       const pkgTransforms = [].concat(
         json.browserify && json.browserify.transform
-      )
+      ).filter(Boolean)
 
       map(pkgTransforms, 10, function (transform, next) {
         transform = Array.isArray(transform) ? transform : [transform]


### PR DESCRIPTION
To avoid `Module build failed: Error: path must be a string` when you are trying to resolve a package that hasn't fully defined a `browserify` + transform config.